### PR TITLE
fix(docs): ignore default export when parsing components with react-docgen

### DIFF
--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -44,9 +44,7 @@ class Image extends Component {
   }
 }
 
-export const Image_ = createComponent(Image, {
+export default createComponent(Image, {
   rules: imageRules,
   variables: imageVariables,
 })
-
-export default Image

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,1 +1,1 @@
-export { Image_ as default } from './Image'
+export Image from './Image'

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -144,8 +144,6 @@ class Layout extends React.Component {
   }
 }
 
-export const Layout_ = createComponent(Layout, {
+export default createComponent(Layout, {
   rules: layoutRules,
 })
-
-export default Layout

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -1,1 +1,1 @@
-export { Layout_ as default } from './Layout'
+export default from './Layout'

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import createComponent from '../../lib/createComponent'
-import { ListItem_ as ListItem } from './ListItem'
+import ListItem from './ListItem'
 import listRules from './listRules'
 
 class List extends React.Component {
@@ -75,8 +75,6 @@ class List extends React.Component {
   }
 }
 
-export const List_ = createComponent(List, {
+export default createComponent(List, {
   rules: listRules,
 })
-
-export default List

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -166,9 +166,7 @@ class ListItem extends React.Component {
   }
 }
 
-export const ListItem_ = createComponent(ListItem, {
+export default createComponent(ListItem, {
   rules: listItemRules,
   variables: listVariables,
 })
-
-export default ListItem

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,1 +1,1 @@
-export { List_ as default } from './List'
+export default from './List'


### PR DESCRIPTION
react-docgen can't handle wrapped components. For now, an easy fix is to ignore the default export and instead look for all React component definitions in a file (we currently only ever define one). If this limits us down the road we can evaluate a fix at that time, but this seems fairly reasonable for the time being.