### PR TITLE
Docs: rtl preview support

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.js
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControls.js
@@ -8,16 +8,19 @@ import ComponentControlsEditCode from './ComponentControlsEditCode'
 import ComponentControlsShowVariables from './ComponentControlsShowVariables'
 import ComponentControlsMaximize from './ComponentControlsMaximize'
 import ComponentControlsShowHtml from './ComponentControlsShowHtml'
+import ComponentControlsRtl from './ComponentControlsRtl'
 
 const ComponentControls = (props) => {
   const {
     anchorName,
     examplePath,
     showHTML,
+    showRtl,
     showCode,
     showVariables,
     onCopyLink,
     onShowHTML,
+    onShowRtl,
     onShowCode,
     onShowVariables,
     visible,
@@ -34,6 +37,7 @@ const ComponentControls = (props) => {
           <ComponentControlsEditCode active={showCode} onClick={onShowCode} />
           <ComponentControlsShowVariables active={showVariables} onClick={onShowVariables} />
           <ComponentControlsShowHtml active={showHTML} onClick={onShowHTML} />
+          <ComponentControlsRtl active={showRtl} onClick={onShowRtl} />
           <ComponentControlsMaximize examplePath={examplePath} />
           <ComponentControlsCopyLink anchorName={anchorName} onClick={onCopyLink} />
         </Menu>
@@ -48,13 +52,15 @@ ComponentControls.propTypes = {
   onCopyLink: PropTypes.func,
   onShowCode: PropTypes.func,
   onShowHTML: PropTypes.func,
+  onShowRtl: PropTypes.func,
   onShowVariables: PropTypes.func,
   showCode: PropTypes.bool,
   showHTML: PropTypes.bool,
+  showRtl: PropTypes.bool,
   showVariables: PropTypes.bool,
   visible: PropTypes.bool,
 }
 
-export default updateForKeys(['showCode', 'showHTML', 'showVariables', 'visible'])(
+export default updateForKeys(['showCode', 'showHTML', 'showRtl', 'showVariables', 'visible'])(
   ComponentControls,
 )

--- a/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsRtl.js
+++ b/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsRtl.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Icon, Menu } from 'semantic-ui-react'
+
+import { updateForKeys } from 'docs/src/hoc'
+import ComponentControlsToolTip from './ComponentControlsToolTip'
+
+const ComponentControlsShowRtl = ({ active, onClick }) => (
+  <ComponentControlsToolTip content='Switch to RTL'>
+    <Menu.Item active={active} onClick={onClick}>
+      <Icon color={active ? 'green' : 'grey'} size='large' name='align right' fitted />
+    </Menu.Item>
+  </ComponentControlsToolTip>
+)
+
+ComponentControlsShowRtl.propTypes = {
+  active: PropTypes.bool,
+  onClick: PropTypes.func,
+}
+
+export default updateForKeys(['active'])(ComponentControlsShowRtl)

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -377,7 +377,7 @@ class ComponentExample extends PureComponent {
   getComponentName = () => this.props.examplePath.split('/')[1]
 
   renderWithProvider = ExampleComponent => (
-    <Provider componentVariables={this.state.componentVariables}>
+    <Provider componentVariables={this.state.componentVariables} rtl={this.state.showRtl}>
       <ExampleComponent knobs={this.getKnobsValue()} />
     </Provider>
   )

--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.js
@@ -108,14 +108,15 @@ class ComponentExample extends PureComponent {
     this.setState({
       showCode: false,
       showHTML: false,
+      showRtl: false,
       showVariables: false,
     })
   }
 
   isActiveState = () => {
-    const { showCode, showHTML, showVariables } = this.state
+    const { showCode, showHTML, showRtl, showVariables } = this.state
 
-    return showCode || showHTML || showVariables
+    return showCode || showHTML || showRtl || showVariables
   }
 
   isActiveHash = () => this.anchorName === getFormattedHash(this.props.location.hash)
@@ -175,6 +176,17 @@ class ComponentExample extends PureComponent {
     const { showHTML } = this.state
 
     this.setState({ showHTML: !showHTML }, this.updateHash)
+  }
+
+  handleShowRtlClick = (e) => {
+    e.preventDefault()
+
+    const { showRtl } = this.state
+
+    this.setState({ showRtl: !showRtl }, () => {
+      this.updateHash()
+      this.renderSourceCode()
+    })
   }
 
   handleShowVariablesClick = (e) => {
@@ -544,6 +556,7 @@ class ComponentExample extends PureComponent {
       isHovering,
       showCode,
       showHTML,
+      showRtl,
       showVariables,
     } = this.state
 
@@ -591,9 +604,11 @@ class ComponentExample extends PureComponent {
                 onCopyLink={this.handleDirectLinkClick}
                 onShowCode={this.handleShowCodeClick}
                 onShowHTML={this.handleShowHTMLClick}
+                onShowRtl={this.handleShowRtlClick}
                 onShowVariables={this.handleShowVariablesClick}
                 showCode={showCode}
                 showHTML={showHTML}
+                showRtl={showRtl}
                 showVariables={showVariables}
                 visible={isActive || isHovering}
               />
@@ -614,7 +629,7 @@ class ComponentExample extends PureComponent {
 
           <Grid.Row columns={1}>
             <Grid.Column className={`rendered-example ${this.getKebabExamplePath()}`}>
-              {exampleElement}
+              <div dir={this.state.showRtl ? 'rtl' : undefined}>{exampleElement}</div>
             </Grid.Column>
             <Grid.Column>
               {this.renderJSX()}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "fela-plugin-fallback-value": "^5.0.17",
     "fela-plugin-placeholder-prefixer": "^5.0.18",
     "fela-plugin-prefixer": "^5.0.18",
+    "fela-plugin-rtl": "^1.0.6",
     "hoist-non-react-statics": "^2.5.0",
     "keyboard-key": "^1.0.1",
     "lodash": "^4.17.10",

--- a/src/components/Provider/Provider.js
+++ b/src/components/Provider/Provider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Provider as RendererProvider, ThemeProvider } from 'react-fela'
 
-import { felaRenderer } from '../../lib'
+import { felaRenderer as felaLtrRenderer, felaRtlRenderer } from '../../lib'
 import ProviderConsumer from './ProviderConsumer'
 
 /**
@@ -30,12 +30,13 @@ class Provider extends Component {
     staticStyles: PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
     ),
+    rtl: PropTypes.bool,
     children: PropTypes.element.isRequired,
   }
 
   static Consumer = ProviderConsumer
 
-  renderStaticStyles = () => {
+  renderStaticStyles = (felaRenderer) => {
     const { siteVariables, staticStyles } = this.props
 
     if (!staticStyles) return
@@ -63,7 +64,7 @@ class Provider extends Component {
     })
   }
 
-  renderFontFaces = () => {
+  renderFontFaces = (felaRenderer) => {
     const { siteVariables, fontFaces } = this.props
 
     if (!fontFaces) return
@@ -83,8 +84,9 @@ class Provider extends Component {
   }
 
   componentDidMount() {
-    this.renderStaticStyles()
-    this.renderFontFaces()
+    const felaRenderer = this.props.rtl ? felaRtlRenderer : felaLtrRenderer
+    this.renderStaticStyles(felaRenderer)
+    this.renderFontFaces(felaRenderer)
   }
 
   render() {
@@ -93,7 +95,7 @@ class Provider extends Component {
     const theme = { siteVariables, componentVariables }
 
     return (
-      <RendererProvider renderer={felaRenderer}>
+      <RendererProvider renderer={this.props.rtl ? felaRtlRenderer : felaLtrRenderer}>
         {siteVariables || componentVariables ? (
           <ThemeProvider theme={theme}>{children}</ThemeProvider>
         ) : (

--- a/src/lib/felaRenderer.js
+++ b/src/lib/felaRenderer.js
@@ -2,17 +2,24 @@ import { createRenderer } from 'fela'
 import felaPluginFallbackValue from 'fela-plugin-fallback-value'
 import felaPluginPlaceholderPrefixer from 'fela-plugin-placeholder-prefixer'
 import felaPluginPrefixer from 'fela-plugin-prefixer'
+import rtl from 'fela-plugin-rtl'
 
-const felaRenderer = createRenderer({
-  plugins: [],
-  middleware: [
-    felaPluginPlaceholderPrefixer(),
-    felaPluginPrefixer(),
-    // Heads up!
-    // This is required after fela-plugin-prefixer to resolve the array of fallback values prefixer produces.
-    felaPluginFallbackValue(),
-  ],
-  enhancers: [],
-})
+function createRendererConfig(isRtl = false) {
+  return {
+    plugins: [
+      felaPluginPlaceholderPrefixer(),
+      felaPluginPrefixer(),
+      // Heads up!
+      // This is required after fela-plugin-prefixer to resolve the array of fallback values prefixer produces.
+      felaPluginFallbackValue(),
+      ...(isRtl ? [rtl()] : []),
+    ],
+    enhancers: [],
+    ...(isRtl ? { selectorPrefix: 'rtl_' } : {}),
+  }
+}
+
+export const felaRenderer = createRenderer(createRendererConfig())
+export const felaRtlRenderer = createRenderer(createRendererConfig(true))
 
 export default felaRenderer

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -5,7 +5,7 @@ export * as customPropTypes from './customPropTypes'
 
 export { debug, makeDebugger } from './debug'
 export eventStack from './eventStack'
-export felaRenderer from './felaRenderer'
+export { felaRenderer, felaRtlRenderer } from './felaRenderer'
 
 export * from './factories'
 export getUnhandledProps from './getUnhandledProps'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,6 +3417,12 @@ fela-plugin-prefixer@^5.0.18:
     inline-style-prefixer "^4.0.0"
     isobject "^3.0.1"
 
+fela-plugin-rtl@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fela-plugin-rtl/-/fela-plugin-rtl-1.0.6.tgz#284fb28e72b8fc845a231c27f001005587e2235e"
+  dependencies:
+    rtl-css-js "^1.1.3"
+
 fela-tools@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/fela-tools/-/fela-tools-5.1.6.tgz#cecdf8ad865adc59aa5ce2952f9daec761bdd740"
@@ -7594,6 +7600,10 @@ rst-selector-parser@^2.2.3:
 rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+
+rtl-css-js@^1.1.3:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.10.0.tgz#958ac1fa68ef5ff4c241e4aa26cf77365d8993d7"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Added possibility to preview a component in RTL (right-to-left)

- the component is wrapped inside a div element with `dir="auto"`
- component's CSS is processed by fela-rtl plugin
- fullscreen view still does NOT support RTL