### PR TITLE
fix: build error

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -11,4 +11,4 @@ require('./gulp/tasks/dist')
 require('./gulp/tasks/docs')
 
 // global tasks
-task('build', parallel('build:dist'))
+task('build', series('dll', parallel('dist', 'build:docs')))

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "gulp --series dll build",
+    "build": "gulp build",
     "build:docs": "gulp --series dll build:docs",
     "build:dist": "gulp --series dll build:dist",
     "ci": "yarn tsd:lint && yarn tsd:test && yarn lint && yarn test",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "gulp build",
+    "build": "gulp --series dll build",
     "build:docs": "gulp --series dll build:docs",
     "build:dist": "gulp --series dll build:dist",
     "ci": "yarn tsd:lint && yarn tsd:test && yarn lint && yarn test",


### PR DESCRIPTION
For the following sequence of commands on clean env

- yarn install
- npm run build

the following error is provided (apparently, due to absence of 'vendor-manifest.json' which is generated as part of the 'dll' task):

> [15:08:24] Error: Cannot find module 'C:\Playgrounds\teams-stardust-levi2\dll\vendor-manifest.json'
>     at Function.Module._resolveFilename (module.js:547:15)
>     at Function.Module._load (module.js:474:25)
>     at Module.require (module.js:596:17)
>     at require (internal/module.js:11:18)

This one has been introduced to the build sequence