### PR TITLE
[DocGen] Improve explicitness over component file naming conventions

### DIFF
--- a/gulp/tasks/docs.ts
+++ b/gulp/tasks/docs.ts
@@ -55,12 +55,7 @@ task(
 // Build
 // ----------------------------------------
 
-const componentsSrc = [
-  `${config.paths.src()}/components/*/[A-Z]*.tsx`,
-  '!**/index.{ts,tsx}',
-  '!**/*Rules.{ts,tsx}',
-  '!**/*Variables.{ts,tsx}',
-]
+const componentsSrc = [`${config.paths.src()}/components/*/[A-Z]*.tsx`]
 
 const examplesSrc = `${paths.docsSrc()}/examples/*/*/*/index.tsx`
 

--- a/gulp/tasks/docs.ts
+++ b/gulp/tasks/docs.ts
@@ -56,7 +56,7 @@ task(
 // ----------------------------------------
 
 const componentsSrc = [
-  `${config.paths.src()}/components/*/*.tsx`,
+  `${config.paths.src()}/components/*/[A-Z]*.tsx`,
   '!**/index.{ts,tsx}',
   '!**/*Rules.{ts,tsx}',
   '!**/*Variables.{ts,tsx}',


### PR DESCRIPTION
As we have an agreement that component files should start with a capital letter, we should explicitly reflect this convention in the discovery pattern for component files for docs generation process. This would save us from necessity to introduce exclusion patterns each time when new utility file is introduced for the component (say, buttonUtils.tsx in Button directory, the one that would provide utility functions with reliance of TSX syntax)