### PR TITLE
Removed hash update from RTL

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -174,7 +174,6 @@ class ComponentExample extends PureComponent<any, any> {
     const { showRtl } = this.state
 
     this.setState({ showRtl: !showRtl }, () => {
-      this.updateHash()
       this.renderSourceCode()
     })
   }


### PR DESCRIPTION
Hash update is now removed from the RTL examples, if we need to remove it from some other icons, we can do it in this PR. @levithomason 