### PR TITLE
[WIP] Modular functional approach to createComponent()

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames'
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { createComponent, customPropTypes, getUnhandledProps, getElementType } from '../../lib'
+import { createComponentAlt, customPropTypes, getUnhandledProps, getElementType } from '../../lib'
 import ListItem from './ListItem'
 import listRules from './listRules'
 
@@ -57,22 +57,26 @@ class List extends React.Component<any, any> {
   static itemProps = ['debug', 'selection', 'truncateContent', 'truncateHeader', 'variables']
 
   render() {
-    const { className, items, styles } = this.props
-
     const ElementType = getElementType(List, this.props)
-    const rest = getUnhandledProps(List, this.props)
+    const { className, items } = this.props
 
-    const classes = cx('ui-list', styles.root, className)
-    const itemProps = _.pick(this.props, List.itemProps)
+    return applyStyles(this.props, ({ styles, variables }) => {
+      const classes = cx('ui-list', styles.root, className)
+      const rest = getUnhandledProps(List, this.props)
 
-    return (
-      <ElementType className={classes} {...rest}>
-        {_.map(items, item => ListItem.create(item, { defaultProps: itemProps }))}
-      </ElementType>
-    )
+      const itemProps = _.pick(this.props, List.itemProps)
+
+      return (
+        <ElementType className={classes} {...rest}>
+          {_.map(items, item => ListItem.create(item, { defaultProps: itemProps }))}
+        </ElementType>
+      )
+    })
   }
 }
 
-export default createComponent(List, {
+const applyStyles = createComponentAlt(List, {
   rules: listRules,
 })
+
+export default List

--- a/src/lib/createComponent_alt.tsx
+++ b/src/lib/createComponent_alt.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const { connect, FelaTheme } = require('react-fela')
+
+import callable from './callable'
+import { createShorthandFactory } from './factories'
+
+interface IStylesConfig {
+  /**
+   * provide rules for styling component
+   * essentilally is a set of functions that translate component's props to styles
+   */
+  rules?: any
+
+  /**
+   * define style parametrized values
+   */
+  variables?: any
+}
+
+type InnerComponent = ({ styles, variables }: { styles: any; variables: any }) => any
+
+// essentially, it is all about producing styles at the end
+
+/**
+ * Introduces general styling support
+ *
+ * @param ComponentType - component type
+ * @param config - all the necessary stuff for configuring styles at the point of initialization
+ */
+const registerStyles = (ComponentType: React.ComponentType, config: IStylesConfig) => {
+  ComponentType.propTypes = {
+    ...ComponentType.propTypes,
+    variables: PropTypes.object,
+  }
+
+  const displayName = ComponentType.displayName
+
+  const { rules, variables } = config
+
+  const appendStylesToProps: (component: any) => React.ComponentType = rules
+    ? connect(rules)
+    : component => component
+
+  return (props: any, innerComponent: InnerComponent) => {
+    const tree = (
+      <FelaTheme
+        render={({ siteVariables = {}, componentVariables = {} }) => {
+          const variablesFromFile = callable(variables)(siteVariables)
+          const variablesFromTheme = callable(componentVariables[displayName])(siteVariables)
+          const variablesFromProp = callable(props.variables)(siteVariables)
+
+          const mergedVariables = Object.assign(
+            {},
+            variablesFromFile,
+            variablesFromTheme,
+            variablesFromProp,
+          )
+
+          const InnerComponentWithStylesInProps = appendStylesToProps(innerComponent)
+
+          // here we are polluting component's props with additional 'variable' prop
+          return <InnerComponentWithStylesInProps {...props} variables={mergedVariables} />
+        }}
+      />
+    )
+
+    return tree
+  }
+}
+
+/**
+ * Introduce shorthand 'create' method to component type
+ * @param ComponentType - component type
+ * @param shorthand - shorthand to introduce
+ */
+const applyShorthand = (ComponentType: React.ComponentType, shorthand: any) => {
+  if (shorthand) {
+     (ComponentType as any).create = createShorthandFactory(ComponentType, shorthand)
+  }
+}
+
+/**
+ * General functionality for creating component. Represents facade on top of domain-specific building blocks.
+ *
+ * @param ComponentType - component type
+ * @param config - configuration spec
+ */
+const createComponent = (
+  ComponentType: React.ComponentType,
+  config: IStylesConfig & { shorthand?: any },
+) => {
+  applyShorthand(ComponentType, config.shorthand)
+  return registerStyles(ComponentType, config)
+}
+
+export default createComponent

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -11,6 +11,8 @@ export * from './factories'
 export { default as getUnhandledProps } from './getUnhandledProps'
 export { default as getElementType } from './getElementType'
 export { default as createComponent } from './createComponent'
+export { default as createComponentAlt } from './createComponent_alt'
+
 export {
   htmlImageProps,
   htmlInputAttrs,


### PR DESCRIPTION
The following general benefits of this approach should be considered:
- Component's element is always the top-level one in the rendered components tree (not wrapped by other components, such as FelaTheme and Fela<...> responsible for applying styles)
   - thus, it seems that there is no need in the following `wrapped` props definitions anymore:
```
  UIComponent.wrappedComponent = `${Component.displayName || Component.name || 'Anonymous'}`
  UIComponent.wrappedComponentPropTypes = Component.propTypes
  UIComponent.wrappedComponentDefaultProps = Component.defaultProps
  UIComponent.wrappedComponentAutoControlledProps = Component.autoControlledProps
```
- number of components in the rendered tree is minimal possible (lesser than we have now with current `createElement` implementation, the same as we would have with base class)
- `props` are not "polluted" with the styling members, such as ''styles" and "variables" - it is up to client code how to consume them
- all the logic is provided in dedicated isolated functions, as well as are separated static and instance-related aspects of this general functionality