### PR TITLE
Run tests in serially for ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: yarn lint
       - run:
           name: Test JavaScript
-          command: yarn test
+          command: yarn test --runInBand
       - run:
           name: Report coverage
           command: bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "transform": {
       "^.+\\.(ts|tsx)$": "ts-jest"
     },
+    "roots": [
+      "<rootDir>/test/specs"
+    ],
     "moduleNameMapper": {
       "docs/(.*)$": "<rootDir>/docs/$1",
       "src/(.*)$": "<rootDir>/src/$1",


### PR DESCRIPTION
circleci is having issues running tests in parallel.  Jest suggests adding the flag: --runInBand when running on an external ci system.

Currently the tests timeout, and run out of memory in circle ci.