### PR TITLE
Add code coverage support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "satisfied": "satisfied --skip-invalid",
     "pretest": "yarn satisfied && gulp build:docs:docgen",
     "test": "cross-env NODE_ENV=test jest",
-    "test:codecov": "yarn test:coverage && codecov",
+    "test:codecov": "yarn test:coverage && codecov -t e2639a78-696f-4768-b27f-1cb328a7a7bf",
     "test:coverage": "yarn test --coverage",
     "test:watch": "yarn test --watchAll",
     "generate:component": "gulp generate:component"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "codecov": "^3.0.2",
     "fbjs": "^0.8.16",
     "fela": "^6.1.7",
     "fela-plugin-fallback-value": "^5.0.17",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "satisfied": "satisfied --skip-invalid",
     "pretest": "yarn satisfied && gulp build:docs:docgen",
     "test": "cross-env NODE_ENV=test jest",
+    "test:codecov": "yarn test:coverage && codecov",
+    "test:coverage": "yarn test --coverage",
     "test:watch": "yarn test --watchAll",
     "generate:component": "gulp generate:component"
   },
@@ -53,6 +55,7 @@
   },
   "homepage": "https://github.com/stardust-ui/stardust#readme",
   "jest": {
+    "coverageDirectory": "./coverage/",
     "testRegex": "/test/.*-test\\.tsx?$",
     "moduleFileExtensions": [
       "ts",
@@ -75,6 +78,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "codecov": "^3.0.2",
     "fbjs": "^0.8.16",
     "fela": "^6.1.7",
     "fela-plugin-fallback-value": "^5.0.17",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "satisfied": "satisfied --skip-invalid",
     "pretest": "yarn satisfied && gulp build:docs:docgen",
     "test": "cross-env NODE_ENV=test jest --coverage",
-    "test:codecov": "yarn test && codecov",
     "test:watch": "yarn test --watchAll",
     "generate:component": "gulp generate:component"
   },

--- a/package.json
+++ b/package.json
@@ -31,9 +31,8 @@
     "start": "gulp --series dll docs",
     "satisfied": "satisfied --skip-invalid",
     "pretest": "yarn satisfied && gulp build:docs:docgen",
-    "test": "cross-env NODE_ENV=test jest",
-    "test:codecov": "yarn test:coverage && codecov -t e2639a78-696f-4768-b27f-1cb328a7a7bf",
-    "test:coverage": "yarn test --coverage",
+    "test": "cross-env NODE_ENV=test jest --coverage",
+    "test:codecov": "yarn test && codecov",
     "test:watch": "yarn test --watchAll",
     "generate:component": "gulp generate:component"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,6 +273,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 arr-diff@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
@@ -1188,6 +1192,14 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+codecov@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.2.tgz#aea43843a5cd2fb6b7e488b2eff25d367ab70b12"
+  dependencies:
+    argv "0.0.2"
+    request "^2.81.0"
+    urlgrey "0.4.4"
 
 collapse-white-space@^1.0.0:
   version "1.0.4"
@@ -6237,7 +6249,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.83.0:
+request@^2.81.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -7464,6 +7476,10 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urlgrey@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 use@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Adds support for showing code coverage report with jest with `yarn test` These will be used with the CI and code coverage systems for PRs.