### PR TITLE
[FIX][Styles][Theming] Fix nested themes extensibility logic

### DIFF
--- a/src/components/Provider/Provider.tsx
+++ b/src/components/Provider/Provider.tsx
@@ -92,6 +92,8 @@ class Provider extends Component<any, any> {
   render() {
     const { componentVariables, siteVariables, children } = this.props
 
+    // ensure we don't assign `undefined` values to the theme context
+    // they will override values down stream
     const theme: any = {}
     if (siteVariables) {
       theme.siteVariables = siteVariables

--- a/src/components/Provider/Provider.tsx
+++ b/src/components/Provider/Provider.tsx
@@ -92,7 +92,13 @@ class Provider extends Component<any, any> {
   render() {
     const { componentVariables, siteVariables, children } = this.props
 
-    const theme = { siteVariables, componentVariables }
+    const theme: any = {}
+    if (siteVariables) {
+      theme.siteVariables = siteVariables
+    }
+    if (componentVariables) {
+      theme.componentVariables = componentVariables
+    }
 
     return (
       <RendererProvider renderer={this.props.rtl ? felaRtlRenderer : felaLtrRenderer}>


### PR DESCRIPTION
There is the following logic that we currently apply for augment themes via nesting fela ThemeProvider components. For the sake of example, suppose that we have the following ThemeProvider components in the tree:

```jsx
<ThemeProvider theme={ siteVariables={.. }, componentVariables=undefined }>
  ...
  <ThemeProvider theme={ siteVariables=undefined, componentVariables={...} />
 ...
</ThemeProvider>
```

In that case merged theme object will be the following (Fela applies logic semantically similar to Object.assign) `{ siteVariables=undefined, componentVariables={...} }`. As one might see, with that, essentially, we are losing information about global siteVariables that were initially defined (and those are critical to calculate style rules). Visually it will result in styles being reset for the component. And, in its turn, this is exactly the case for the Provider's component logic, which originally introduced ThemeProvider object on the aforementioned way.

This fix is aimed on address this issue. With this one we would be able to properly apply 'local' styling variables to component example, without losing information about global 'siteVariables'.

However, there are still limitations on how we could extend, say, `componentVariables` object via nesting theme components. Unfortunately, with current approach taken it won't be possible to achieve, but have couple of ideas how we could address this problem as well. @levithomason, please, let me know if it is fine for me to start on prototyping these solutions.