### PR TITLE
[FIX][Docs][Styles] Fix component styles customization logic

### DIFF
--- a/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -466,6 +466,7 @@ class ComponentExample extends PureComponent<any, any> {
         componentVariables: {
           ...state.componentVariables,
           [component]: {
+            ...(state.componentVariables && state.componentVariables[component]),
             [variable]: value,
           },
         },


### PR DESCRIPTION
Fix logic that is responsible for applying custom variable values to component styles. There was a bug that only one custom variable (that was set last) is applied to component's styles in Docs. With that it was impossible, say, to see an effect of both values of `circularRadius` and `circularWidth` values being applied for Button component at the same time.

* Requires #55 to be merged to clearly see the issue being fixed.