### PR TITLE
chore(.github): add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# https://help.github.com/articles/about-codeowners/
+
+# Default owners
+* @kuzhelov @levithomason @mnajdova


### PR DESCRIPTION
This PR informs GitHub of who is allowed to approve PRs.