### PR TITLE
fix: normalize css

### DIFF
--- a/src/themes/teams/normalizeCSS.tsx
+++ b/src/themes/teams/normalizeCSS.tsx
@@ -193,11 +193,6 @@ button,
 [type="reset"],
 [type="submit"] {
   -webkit-appearance: button;
-  margin: 0 0.25rem 0 0;
-  border: .1rem solid;
-  border-radius: .3rem;
-  height: 32px;
-  width: 96px;
 }
 
 /**


### PR DESCRIPTION
We somehow got a rogue style added for `button` in `normalizeCSS`.  We'll need a better way to manage our reset moving forward, but I've just updated it for now.