### PR TITLE
fix(Button): add missing styles

### DIFF
--- a/src/components/Button/buttonRules.ts
+++ b/src/components/Button/buttonRules.ts
@@ -1,3 +1,4 @@
+import { pxToRem } from '../../lib'
 import { IButtonVariables } from './buttonVariables'
 
 export default {
@@ -20,13 +21,16 @@ export default {
     return {
       backgroundColor,
       display: 'inline-block',
+      margin: `0 ${pxToRem(8)} 0 0`,
+      height: pxToRem(32),
+      width: pxToRem(96),
       verticalAlign: 'middle',
       cursor: 'pointer',
       borderWidth: 0,
+      borderRadius: pxToRem(4),
       ':hover': {
         backgroundColor: backgroundColorHover,
       },
-
       ...(props.circular && { borderRadius: circularRadius, width: circularWidth }),
 
       ...(props.type === 'primary' && {


### PR DESCRIPTION
When normalize.css was fixed (#79), these styles were removed.  Seems they were added to normalize.css by mistake initially.

# Before

![image](https://user-images.githubusercontent.com/5067638/42664858-e0e7cd58-85f1-11e8-9846-b043d766e3a8.png)

# After

![image](https://user-images.githubusercontent.com/5067638/42664846-d397e1ce-85f1-11e8-822a-be98f8ae5e3d.png)
