### PR TITLE
[RFC] Made BaseComponent abstract, to leverage compiletime verification

### DIFF
--- a/src/lib/AutoControlledComponent.tsx
+++ b/src/lib/AutoControlledComponent.tsx
@@ -71,7 +71,7 @@ export const getAutoControlledStateValue = (
   // otherwise, undefined
 }
 
-export default class AutoControlledComponent<P, S> extends UIComponent<P, S> {
+export default abstract class AutoControlledComponent<P, S> extends UIComponent<P, S> {
   constructor(props, ctx) {
     super(props, ctx)
 

--- a/src/lib/UIComponent.tsx
+++ b/src/lib/UIComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import renderComponent, { IRenderResultConfig } from './renderComponent'
 
-class UIComponent<P, S> extends React.Component<P, S> {
+abstract class UIComponent<P, S> extends React.Component<P, S> {
   private readonly childClass = this.constructor as typeof UIComponent
   static defaultProps: { [key: string]: any }
   static displayName: string
@@ -12,21 +12,11 @@ class UIComponent<P, S> extends React.Component<P, S> {
 
   constructor(props, context) {
     super(props, context)
-    if (process.env.NODE_ENV !== 'production') {
-      const child = this.constructor
-      const childName = child.name
-
-      if (typeof this.renderComponent !== 'function') {
-        throw new Error(`${childName} extending UIComponent is missing a renderComponent() method.`)
-      }
-    }
 
     this.renderComponent = this.renderComponent.bind(this)
   }
 
-  renderComponent(config: IRenderResultConfig<P>): React.ReactNode {
-    throw new Error('renderComponent is not implemented.')
-  }
+  abstract renderComponent(config: IRenderResultConfig<P>): React.ReactNode
 
   render() {
     return renderComponent(

--- a/test/specs/lib/AutoControlledComponent-test.tsx
+++ b/test/specs/lib/AutoControlledComponent-test.tsx
@@ -3,17 +3,21 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { AutoControlledComponent } from 'src/lib'
 import { consoleUtil } from 'test/utils'
+import { IRenderResultConfig } from 'src/lib/renderComponent'
 
 let TestClass
 
 const createTestClass = (options = {}) =>
-  class Test extends AutoControlledComponent {
-    static autoControlledProps = options.autoControlledProps
-    static defaultProps = options.defaultProps
+  class Test extends AutoControlledComponent<{}, {}> {
+    static autoControlledProps = (options as any).autoControlledProps
+    static defaultProps = (options as any).defaultProps
     getInitialAutoControlledState() {
-      return options.state
+      return (options as any).state
     }
-    render = () => <div />
+    renderComponent(config: IRenderResultConfig<{}>): React.ReactNode {
+      return <div />
+    }
+    // render = () => <div />
   }
 
 const toDefaultName = prop => `default${prop.slice(0, 1).toUpperCase() + prop.slice(1)}`


### PR DESCRIPTION
To achieve better performance and remove unnecessary runtime verifications, UIComponent and AutoControlledComponent has been made abstract. This helps us to detect potential problems on earlier stages of development with using compile time verification instead of runtime checks.