### PR TITLE
feat(Menu): Update styling for *primary underlined* to match Teams style

### DIFF
--- a/src/components/Menu/menuItemRules.ts
+++ b/src/components/Menu/menuItemRules.ts
@@ -1,7 +1,7 @@
 import { pxToRem } from '../../lib'
 
 const underlinedItem = (color: string) => ({
-  borderBottom: `solid 5px ${color}`,
+  borderBottom: `solid 4px ${color}`,
   transition: 'color .1s ease',
 })
 
@@ -21,7 +21,11 @@ export default {
         borderRadius: pxToRem(5),
       }),
       ...(shape === 'underlined' && {
-        margin: '0',
+        padding: '0',
+        margin: `0 ${pxToRem(10)} 0 0`,
+        ':nth-child(n+2)': {
+          marginLeft: `${pxToRem(10)}`,
+        },
         background: 'transparent',
         boxShadow: 'none',
         color: variables.defaultColor,
@@ -101,12 +105,15 @@ export default {
         }),
         ...(shape === 'underlined' && {
           color: variables.defaultColor,
-          fontWeight: '700',
           ...underlinedItem(variables.defaultActiveColor),
-          ...(type === 'primary' && {
-            color: variables.typePrimaryActiveColor,
-            ...underlinedItem(variables.typePrimaryActiveColor),
-          }),
+          ...(type === 'primary'
+            ? {
+                color: variables.typePrimaryActiveColor,
+                ...underlinedItem(variables.typePrimaryActiveColor),
+              }
+            : {
+                fontWeight: '700',
+              }),
         }),
       }),
     }

--- a/src/components/Menu/menuRules.ts
+++ b/src/components/Menu/menuRules.ts
@@ -18,9 +18,9 @@ export default {
           borderRadius: pxToRem(4),
         }),
       ...(shape === 'underlined' && {
-        borderBottom: `1px solid ${variables.defaultBorderColor}`,
+        borderBottom: `2px solid ${variables.typePrimaryUnderlinedBorderColor}`,
       }),
-      minHeight: pxToRem(28),
+      minHeight: pxToRem(24),
       margin: 0,
       padding: 0,
       listStyleType: 'none',

--- a/src/components/Menu/menuVariables.ts
+++ b/src/components/Menu/menuVariables.ts
@@ -10,6 +10,7 @@ export interface IMenuVariables {
   typePrimaryBackgroundColorHover: string
   typePrimaryBorderColor: string
   typePrimaryActiveBorderColor: string
+  typePrimaryUnderlinedBorderColor: string
 }
 
 export default (siteVars: any): IMenuVariables => {
@@ -25,5 +26,6 @@ export default (siteVars: any): IMenuVariables => {
     typePrimaryBackgroundColorHover: siteVars.brand16,
     typePrimaryBorderColor: siteVars.brand08,
     typePrimaryActiveBorderColor: siteVars.brand12,
+    typePrimaryUnderlinedBorderColor: siteVars.gray12,
   }
 }


### PR DESCRIPTION
# Menu underlined primary

Style of the underlined primary menu was updated to match Teams look and feel.

### Stardust Before:
![image](https://user-images.githubusercontent.com/9615899/42883439-e80eb372-8a9b-11e8-8289-25d006f0ad42.png)

### Stardust After:
![image](https://user-images.githubusercontent.com/9615899/42883603-524032fc-8a9c-11e8-95b2-52bf953f7f0c.png)

### Real Teams:
![image](https://user-images.githubusercontent.com/9615899/42883488-04ab86a4-8a9c-11e8-91fd-6c5d66bf4fa9.png)

### TODO

- [x] Conformance test
- [ ] Minimal doc site example
- [ ] Stardust base theme
- [x] Teams Light theme
- [ ] Teams Dark theme
- [ ] Teams Contrast theme
- [x] Confirm RTL usage
- [ ] [W3 accessibility](https://www.w3.org/standards/webdesign/accessibility) check
- [ ] [Stardust accessibility](https://github.com/stardust-ui/accessibility) check
- [ ] ~~Update glossary props table~~
- [ ] Update the CHANGELOG.md

# API Proposal
The main change is that previously the whole menu item was underlined but now only the caption is underlined.

I was thinking about implementing it conditionally using `fitted` prop but I do not see any use for the old look in Teams. For that reason I consider it the only look for underlined menu in Teams theme.