### PR TITLE
docs: improve headings and introduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add shorthand examples for the Label component @mnajdova ([#99](https://github.com/stardust-ui/react/pull/99))
 - Replace `stardust` imports with `@stardust-ui/react` to reflect the new npm package @davezuko ([#115](https://github.com/stardust-ui/react/pull/115]))
 - Further improve code edit experience @levithomason ([#100](https://github.com/stardust-ui/react/pulls/100))
+- Improve general clarity in README @davezuko ([#118](https://github.com/stardust-ui/react/pull/118]))
 
 <!--------------------------------[ v0.2.0 ]------------------------------- -->
 ## [v0.2.0](https://github.com/stardust-ui/react/tree/v0.2.0) (2018-07-10)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
 # Stardust
 
-[Semantic UI React (SUIR)][200] has forked to support two initiatives, Stardust and SUIR v2.
+Stardust is a set of specifications and tools for building UI libraries. It is based on a fork of [Semantic UI React (SUIR)][200], and designed to support two initiatives: Stardust itself and Semantic UI React v2.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Stardust](#stardust)
-  - [Why?](#why)
-  - [Scope](#scope)
-  - [Specifications](#specifications)
-  - [Join](#join)
+- [Why?](#why)
+- [Scope](#scope)
+- [Specifications](#specifications)
+- [Join](#join)
 - [SUIR v2](#suir-v2)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## Stardust
-
-Stardust is a set of specifications and tools for building UI libraries.
-
-### Why?
+## Why?
 
 There are a number of packages that a UI library needs to create great UI components. Take a look at SUIR's [`/src/lib`][201] as an example. This core library enables the SUIR features we love today such as shorthand props, event stack handling, auto controlled state, controlling the rendered component, and more.
 
@@ -27,13 +22,13 @@ Other libraries in the wild have some of these features and some of their own. I
 
 A shared library means more great ideas and more engineering support for features and bug fixes. More importantly, it means more consistency in UI components on the web. We're really excited to see just how far we can take this aspect of collaboration.
 
-### Scope
+## Scope
 
 You can think of Stardust as the internals of a good component library.  This encompasses everything except for the actual UI components themselves.
 
-We are currently discussing which, if any, components will be included.  The collaborative result of our specifications will determine Stardust's final scope. 
+We are currently discussing which, if any, components will be included.  The collaborative result of our specifications will determine Stardust's final scope.
 
-### Specifications
+## Specifications
 
 All our specifications are open for collaboration.  You are also welcome to post your own proposals here.
 
@@ -50,7 +45,7 @@ It is our desire that the patterns and utils around modern component libraries a
 - [HTML Font Size][107]
 - [Parent Child Coupling][108]
 
-### Join
+## Join
 
 Currently, these teams are actively participating in Stardust's specifications and development:
 
@@ -62,7 +57,7 @@ If you own or are building a UI component library, we'd love to have your input.
 
 ## SUIR v2
 
-See the [MANIFESTO.md][1] for details.  SUIR v2 will be built on the specifications and tools from Stardust. 
+See the [MANIFESTO.md][1] for details.  SUIR v2 will be built on the specifications and tools from Stardust.
 
 <!-- REPO -->
 [1]: https://github.com/stardust-ui/react/blob/master/MANIFESTO.md
@@ -86,5 +81,5 @@ See the [MANIFESTO.md][1] for details.  SUIR v2 will be built on the specificati
 
 <!-- EXTERNAL -->
 [300]: https://developer.microsoft.com/en-us/fabric
-[301]: https://products.office.com/en-US/microsoft-teams/group-chat-software 
+[301]: https://products.office.com/en-US/microsoft-teams/group-chat-software
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,13 @@ A shared library means more great ideas and more engineering support for feature
 
 You can think of Stardust as the internals of a good component library. This encompasses everything except for the actual UI components themselves.
 
-We are currently discussing which, if any, components will be included. The collaborative result of our specifications will determine Stardust's final scope.
+We are currently discussing which, if any, components will be included. The collaborative result of our [specifications](#specifications) will determine Stardust's final scope.
 
 ## Specifications
 
-All our specifications are open for collaboration. You are also welcome to post your own proposals here.
+All of our specifications are listed in [/specifications][100], and are open for collaboration. You are also welcome to submit your own proposals via a pull request.
 
-Stardust's specifications are posted to [`/specifications`][100]. We review and discuss specifications via PRs.
-
-It is our desire that the patterns and utils around modern component libraries are not proprietary but the result of collaboration and shared sentiment among library developers and consumers.
+It is our desire that the patterns and utilities around modern component libraries are not proprietary but the result of collaboration and shared sentiment among library developers and consumers.
 
 - [Creating Components][101]
 - [CSS-in-JS][102]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stardust
 
-Stardust is a set of specifications and tools for building UI libraries. It is based on a fork of [Semantic UI React (SUIR)][200], and designed to support two initiatives: Stardust itself and Semantic UI React v2.
+Stardust is a set of specifications and tools for building UI libraries. It is based on a fork of [Semantic UI React (SUIR)][200], and designed to support two initiatives: Stardust itself and SUIR v2.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -10,7 +10,7 @@ Stardust is a set of specifications and tools for building UI libraries. It is b
 - [Scope](#scope)
 - [Specifications](#specifications)
 - [Contribute](#contribute)
-- [SUIR v2](#suir-v2)
+- [Semantic UI React v2](#semantic-ui-react-v2)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -55,7 +55,7 @@ Currently, these teams are actively participating in Stardust's specifications a
 
 If you own or are building a UI component library, we'd love to have your input.  [Post an issue][2] introducing yourself and your team and join us today.
 
-## SUIR v2
+## Semantic UI React v2
 
 See the [MANIFESTO.md][1] for details.  SUIR v2 will be built on the specifications and tools from Stardust.
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ A shared library means more great ideas and more engineering support for feature
 
 ## Scope
 
-You can think of Stardust as the internals of a good component library.  This encompasses everything except for the actual UI components themselves.
+You can think of Stardust as the internals of a good component library. This encompasses everything except for the actual UI components themselves.
 
-We are currently discussing which, if any, components will be included.  The collaborative result of our specifications will determine Stardust's final scope.
+We are currently discussing which, if any, components will be included. The collaborative result of our specifications will determine Stardust's final scope.
 
 ## Specifications
 
-All our specifications are open for collaboration.  You are also welcome to post your own proposals here.
+All our specifications are open for collaboration. You are also welcome to post your own proposals here.
 
-Stardust's specifications are posted to [`/specifications`][100].  We review and discuss specifications via PRs.
+Stardust's specifications are posted to [`/specifications`][100]. We review and discuss specifications via PRs.
 
 It is our desire that the patterns and utils around modern component libraries are not proprietary but the result of collaboration and shared sentiment among library developers and consumers.
 
@@ -53,11 +53,11 @@ Currently, these teams are actively participating in Stardust's specifications a
 - [Office UI Fabric][300]
 - [Teams (Microsoft)][301]
 
-If you own or are building a UI component library, we'd love to have your input.  [Post an issue][2] introducing yourself and your team and join us today.
+If you own or are building a UI component library, we'd love to have your input. [Post an issue][2] introducing yourself and your team and join us today.
 
 ## Semantic UI React v2
 
-See the [MANIFESTO.md][1] for details.  SUIR v2 will be built on the specifications and tools from Stardust.
+See the [MANIFESTO.md][1] for details. SUIR v2 will be built on the specifications and tools from Stardust.
 
 <!-- REPO -->
 [1]: https://github.com/stardust-ui/react/blob/master/MANIFESTO.md

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Stardust is a set of specifications and tools for building UI libraries. It is b
 - [Why?](#why)
 - [Scope](#scope)
 - [Specifications](#specifications)
-- [Join](#join)
+- [Contribute](#contribute)
 - [SUIR v2](#suir-v2)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -45,7 +45,7 @@ It is our desire that the patterns and utils around modern component libraries a
 - [HTML Font Size][107]
 - [Parent Child Coupling][108]
 
-## Join
+## Contribute
 
 Currently, these teams are actively participating in Stardust's specifications and development:
 


### PR DESCRIPTION
I see the intention behind the heading, but don't think it really serves a purpose. A secondary "SUIR v2" heading makes just as much sense, and allows the rest of the headings to be more prominent.

Also, @levithomason I was going to clean up the haphazard punctuation spacing (one vs. two spaces after a period) but didn't want to start a war.